### PR TITLE
simple fix: dont treat '0' as padding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,9 @@ pub fn expand(node: &crate::parser::Node) -> Result<Vec<String>, ExpansionError>
             end: _,
         } => {
             // Get the numeric string length to be used later for zero padding
-            let zero_pad = if from.chars().nth(0) == Some('0') || to.chars().nth(0) == Some('0') {
+            let zero_pad = if from.chars().nth(0) == Some('0') && from.len() > 1
+                || to.chars().nth(0) == Some('0')
+            {
                 if from.len() >= to.len() {
                     from.len()
                 } else {
@@ -432,6 +434,25 @@ mod tests {
         assert_eq!(
             bracoxidize("A{1..10}"),
             Ok(vec![
+                "A1".to_owned(),
+                "A2".to_owned(),
+                "A3".to_owned(),
+                "A4".to_owned(),
+                "A5".to_owned(),
+                "A6".to_owned(),
+                "A7".to_owned(),
+                "A8".to_owned(),
+                "A9".to_owned(),
+                "A10".to_owned(),
+            ])
+        )
+    }
+    #[test]
+    fn test_expand_range_no_padding_allowzero_bracoxidize() {
+        assert_eq!(
+            bracoxidize("A{0..10}"),
+            Ok(vec![
+                "A0".to_owned(),
                 "A1".to_owned(),
                 "A2".to_owned(),
                 "A3".to_owned(),


### PR DESCRIPTION
Hi, I was using this crate from nushell and found this behaviour a little bit strange:
```
> : "{0..10}" | str expand
╭────┬────╮
│  0 │ 00 │
│  1 │ 01 │
│  2 │ 02 │
│  3 │ 03 │
│  4 │ 04 │
│  5 │ 05 │
│  6 │ 06 │
│  7 │ 07 │
│  8 │ 08 │
│  9 │ 09 │
│ 10 │ 10 │
╰────┴────╯
```

I think the 0 padding should not affect the digit 0 itself, so this would be expected:
```
> : "{0..10}" | str expand
╭────┬────╮
│  0 │ 0  │
│  1 │ 1  │
│  2 │ 2  │
│  3 │ 3  │
│  4 │ 4  │
│  5 │ 5  │
│  6 │ 6  │
│  7 │ 7  │
│  8 │ 8  │
│  9 │ 9  │
│ 10 │ 10 │
╰────┴────╯
```
I made a simple check to see if the length is greater than 1 and added a simple test.

I don't program in rust, so any suggestions or corrections are appreciated ^^